### PR TITLE
postcss.config.jsをESモジュール構文に修正

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
-module.exports = {
-  plugins: [
-    require('tailwindcss'),
-    require('autoprefixer'),
-  ],
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
 }


### PR DESCRIPTION
## Summary
- `postcss.config.js` の `module.exports` を `export default` に修正
- `package.json` の `"type": "module"` との矛盾を解消
- これにより2024年12月8日以降発生していたVercelビルドエラーが修正される

## Root Cause
`postcss.config.js` がCommonJS構文（`module.exports`）だったが、`package.json` に `"type": "module"` が設定されており、Node.js v22がESモジュールとして解釈しようとしてエラー。

## Test plan
- [x] ローカル `npm run build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Switch PostCSS config from CommonJS to ES module syntax and adjust plugin configuration for Tailwind CSS and Autoprefixer to align with current tooling expectations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostCSS build configuration to align with modern standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->