### PR TITLE
フィードバック画面のレイアウトをコンパクトに変更

### DIFF
--- a/src/components/AnswerFeedback.tsx
+++ b/src/components/AnswerFeedback.tsx
@@ -26,46 +26,43 @@ export const AnswerFeedback: React.FC<AnswerFeedbackProps> = ({
   return (
     // コンポーネントの全体を囲むdiv
     <div className="bg-white/95 backdrop-blur-sm rounded-xl shadow-lg p-6 max-w-md w-full">
-      {/* 中央に配置するためのflexコンテナ */}
       <div className="flex flex-col items-center">
-        {/* 正解か不正解かを示すアイコン */}
-        <div className="mb-4">
-          {isCorrect ? (
-            <CheckCircle2 className="w-16 h-16 text-green-500" /> // 正解の場合のアイコン
-          ) : (
-            <XCircle className="w-16 h-16 text-red-400" /> // 不正解の場合のアイコン
-          )}
-        </div>
-        
-        {/* ポケモンの画像を表示する部分 */}
-        <div className="w-48 h-48 flex items-center justify-center mb-4">
-          <img 
-            src={pokemon.imageUrl} // ポケモンの画像URL
-            alt={pokemon.name.japanese} // ポケモンの日本語名をalt属性に設定
-            className="w-full h-full object-contain" // 画像のスタイル
-          />
-        </div>
-
-        {/* 正解・不正解のメッセージとユーザーの答えを表示する部分 */}
-        <div className="text-center mb-6">
-          <h3 className="text-xl font-bold mb-2 text-gray-900">
-            {isCorrect ? "正解！" : "不正解..."}
-          </h3>
-          <p className="text-lg text-gray-700">
-            正解は「{correctAnswer}」です
-          </p>
-          {!isCorrect && (
-            <p className="text-gray-500 mt-1">
-              あなたの回答: {userAnswer}
+        {/* 上部: アイコン + 画像 + 結果テキストを横並びでコンパクトに */}
+        <div className="flex items-center gap-4 mb-6 w-full">
+          <div className="w-32 h-32 flex-shrink-0 flex items-center justify-center relative">
+            <img
+              src={pokemon.imageUrl}
+              alt={pokemon.name.japanese}
+              className="w-full h-full object-contain"
+            />
+            <div className="absolute -top-2 -right-2">
+              {isCorrect ? (
+                <CheckCircle2 className="w-8 h-8 text-green-500 bg-white rounded-full" />
+              ) : (
+                <XCircle className="w-8 h-8 text-red-400 bg-white rounded-full" />
+              )}
+            </div>
+          </div>
+          <div className="flex-1 text-left">
+            <h3 className="text-xl font-bold mb-1 text-gray-900">
+              {isCorrect ? "正解！" : "不正解..."}
+            </h3>
+            <p className="text-base text-gray-700">
+              正解は「{correctAnswer}」です
             </p>
-          )}
+            {!isCorrect && (
+              <p className="text-gray-500 text-sm mt-1">
+                あなたの回答: {userAnswer}
+              </p>
+            )}
+          </div>
         </div>
 
-        {/* 次の問題へ進むボタン */}
+        {/* ボタン: QuizCardの選択肢ボタンと同じ位置に来るようにする */}
         <button
-          onClick={onNext} // ボタンがクリックされたときにonNext関数を呼び出す
-          className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg
-                   transition-colors duration-200" // ボタンのスタイル
+          onClick={onNext}
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 px-6 rounded-lg
+                   transition-colors duration-200"
         >
           {currentQuestion === totalQuestions ? "テスト結果を表示" : "次の問題へ"}
         </button>


### PR DESCRIPTION
## Summary
- AnswerFeedback画面の画像とテキストを横並びレイアウトに変更
- 「次の問題へ」ボタンをQuizCardの選択肢ボタンと近い高さに配置
- スクロールなしで連続操作できるよう改善

## Before
アイコン → 画像(大) → テキスト → ボタン の縦並びで、ボタンが画面下にずれていた

## After  
[画像+アイコン | テキスト] → ボタン(横幅いっぱい) のコンパクトな横並びレイアウト

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Compact the AnswerFeedback screen layout to reduce vertical space and align the navigation button with the quiz options.

Enhancements:
- Rework the AnswerFeedback header area into a horizontal layout combining Pokémon image, result icon, and text for a more compact presentation.
- Overlay the correctness icon on the Pokémon image and adjust typography for clearer result information.
- Make the next-question button full-width and positioned to align vertically with the QuizCard choice buttons for smoother continuous interaction.