### PR TITLE
Credits表示テキストを正式な著作権表記に変更

### DIFF
--- a/src/components/Credits.tsx
+++ b/src/components/Credits.tsx
@@ -2,23 +2,9 @@ import React from 'react';
 
 export const Credits: React.FC = () => {
   return (
-    <div className="w-full max-w-2xl text-center text-sm text-gray-400 mt-8">
-      <div className="mb-2">
-        <p>ポケモンおよびポケットモンスターは任天堂の商標です</p>
-      </div>
-      <div className="mt-2">
-        <p>
-          データ提供:
-          <a
-            href="https://pokeapi.co/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-blue-400 hover:text-blue-300 transition-colors duration-200 ml-1"
-          >
-            PokéAPI
-          </a>
-        </p>
-      </div>
+    <div className="w-full max-w-2xl text-center text-sm text-gray-400 mt-8 leading-relaxed">
+      <p>本アプリケーションは、非公式かつ個人による制作物です。</p>
+      <p>ポケモンおよび関連するすべてのキャラクター名、画像、商標は、© Pokémon、© Nintendo/Creatures Inc./GAME FREAK inc. に帰属します。</p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- PokéAPIリンク・テキストを削除
- 非公式アプリである旨の表記を追加
- © Pokémon、© Nintendo/Creatures Inc./GAME FREAK inc. の著作権表記を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the Credits component to present official Pokémon copyright attribution and clarify that the application is an unofficial, personal project.

New Features:
- Add explicit notice that the application is an unofficial, individually created project.
- Add formal copyright attribution for Pokémon-related names, images, and trademarks to the appropriate rights holders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised credits and legal notices displayed to users.

* **Style**
  * Minor styling updates to credits section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->