### PR TITLE
OGPキャッシュ対策: description追加 + 画像URLバスター

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,17 +5,18 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>初代ポケモン名前当てクイズ</title>
+    <meta name="description" content="151匹のポケモンの中から、正解を当てるシルエットクイズです。" />
     <!-- Open Graph meta tags -->
     <meta property="og:title" content="初代ポケモン名前当てクイズ" />
     <meta property="og:description" content="151匹のポケモンの中から、正解を当てるシルエットクイズです。" />
-    <meta property="og:image" content="https://quiz-pokemon-151.vercel.app/og-image.png" />
+    <meta property="og:image" content="https://quiz-pokemon-151.vercel.app/og-image.png?v=2" />
     <meta property="og:url" content="https://quiz-pokemon-151.vercel.app/" />
     <meta property="og:type" content="website" />
     <!-- Twitter Card meta tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="初代ポケモン名前当てクイズ" />
     <meta name="twitter:description" content="151匹のポケモンの中から、正解を当てるシルエットクイズです。" />
-    <meta name="twitter:image" content="https://quiz-pokemon-151.vercel.app/og-image.png" />
+    <meta name="twitter:image" content="https://quiz-pokemon-151.vercel.app/og-image.png?v=2" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- `<meta name="description">` タグを追加（XやGoogleがfallback descriptionとして利用）
- `og:image` / `twitter:image` のURLに `?v=2` を付与し、Xのキャッシュを無効化

## 背景
OGPメタタグは正しく更新されているが、X (Twitter) のサーバー側キャッシュが古いdescriptionと画像を保持していた。

## Test plan
- [ ] Vercelデプロイ成功
- [ ] Card Validatorで新しいプレビューが表示されることを確認
- [ ] Xのツイート作成画面で新しいdescription/画像を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add SEO and social sharing metadata improvements for the Pokémon quiz landing page.

New Features:
- Add a standard HTML meta description tag for the quiz page.

Enhancements:
- Append a cache-busting query parameter to Open Graph and Twitter image URLs to force social platform preview updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated page metadata and social sharing image URLs to improve content visibility across social platforms and search engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->