### PR TITLE
@vercel/kvを@upstash/redisに移行（APIエラー修正）

### DIFF
--- a/api/play-count.ts
+++ b/api/play-count.ts
@@ -1,5 +1,10 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { kv } from '@vercel/kv';
+import { Redis } from '@upstash/redis';
+
+const redis = new Redis({
+  url: process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL!,
+  token: process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN!,
+});
 
 const KEY = 'play-count';
 const MAX_COUNT = 65536; // 2^16
@@ -15,16 +20,16 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   try {
     if (req.method === 'GET') {
-      const count = (await kv.get<number>(KEY)) ?? 0;
+      const count = (await redis.get<number>(KEY)) ?? 0;
       return res.status(200).json({ count });
     }
 
     if (req.method === 'POST') {
-      const current = (await kv.get<number>(KEY)) ?? 0;
+      const current = (await redis.get<number>(KEY)) ?? 0;
       if (current >= MAX_COUNT) {
         return res.status(200).json({ count: current, capped: true });
       }
-      const newCount = await kv.incr(KEY);
+      const newCount = await redis.incr(KEY);
       return res.status(200).json({ count: newCount });
     }
 

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "pokemon-quiz-app",
       "version": "0.0.0",
       "dependencies": {
-        "@vercel/kv": "^3.0.0",
+        "@upstash/redis": "^1.36.2",
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
@@ -1983,19 +1983,6 @@
       "integrity": "sha512-CqC01WZxbLUxoiVdh9B/poPbNpY9U+tO1N9oWHwTl5YAZxcqXmmWJ8KNMFItJCUUWdY3J3xv8LvAuQv2KZ5YdQ==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@vercel/kv": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-3.0.0.tgz",
-      "integrity": "sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==",
-      "deprecated": "Vercel KV is deprecated. If you had an existing KV store, it should have moved to Upstash Redis which you will see under Vercel Integrations. For new projects, install a Redis integration from Vercel Marketplace: https://vercel.com/marketplace?category=storage&search=redis",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@upstash/redis": "^1.34.0"
-      },
-      "engines": {
-        "node": ">=14.6"
-      }
     },
     "node_modules/@vercel/nft": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@vercel/kv": "^3.0.0",
+    "@upstash/redis": "^1.36.2",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"


### PR DESCRIPTION
## Summary
- `@vercel/kv` → `@upstash/redis` に移行
- 環境変数名のフォールバック追加（`KV_REST_API_*` / `UPSTASH_REDIS_REST_*` 両対応）
- `api/tsconfig.json` のモジュール設定を ESNext に修正

## 背景
本番の `/api/play-count` が `FUNCTION_INVOCATION_FAILED` エラーを返していた。`@vercel/kv` パッケージが Vercel の Upstash 統合と互換性の問題を起こしていたため、`@upstash/redis` に直接移行。

## Test plan
- [ ] `curl GET /api/play-count` → `{"count": N}` が返る
- [ ] `curl POST /api/play-count` → カウントが+1される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Migrate the play count API from @vercel/kv to @upstash/redis and adjust TypeScript config to support the new runtime setup.

Bug Fixes:
- Resolve FUNCTION_INVOCATION_FAILED errors in the /api/play-count endpoint by using a compatible Redis client and environment variable fallback handling.

Enhancements:
- Switch the play count storage backend from @vercel/kv to @upstash/redis with support for both KV_REST_API_* and UPSTASH_REDIS_REST_* environment variables.

Build:
- Update api/tsconfig.json module settings to use ESNext modules with bundler-based module resolution.

Chores:
- Replace the @vercel/kv dependency with @upstash/redis in package.json and lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded backend infrastructure for the play count feature.
  * Updated project dependencies and TypeScript configuration for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->